### PR TITLE
Reset the bool connected to false in the method disconnect().

### DIFF
--- a/src/ofxDmx.cpp
+++ b/src/ofxDmx.cpp
@@ -39,6 +39,7 @@ bool ofxDmx::isConnected() {
 
 void ofxDmx::disconnect() {
 	serial.close();
+    connected = false;
 }
 
 void ofxDmx::setChannels(unsigned int channels) {


### PR DESCRIPTION
Hi,

It seems to me that the boolean 'connected' should be set to false when the method disconnect() is called.

Let me know.

Thanks,

Hugues.
