### PR TITLE
fixes for oF 0.10

### DIFF
--- a/src/ofxDmx.cpp
+++ b/src/ofxDmx.cpp
@@ -32,7 +32,7 @@ bool ofxDmx::connect(int device, unsigned int channels) {
 	return connected;
 }
 
-bool ofxDmx::connect(string device, unsigned int channels) {
+bool ofxDmx::connect(std::string device, unsigned int channels) {
 	serial.listDevices();
 	connected = serial.setup(device.c_str(), 57600);
 	setChannels(channels);
@@ -66,7 +66,7 @@ void ofxDmx::activateMk2(unsigned char key0, unsigned char key1, unsigned char k
 	// step 1: set API -key
 	unsigned int dataSize = 4;
 	unsigned int packetSize = DMX_PRO_HEADER_SIZE + dataSize + DMX_PRO_END_SIZE;
-	vector<unsigned char> packet(packetSize);
+	std::vector<unsigned char> packet(packetSize);
 	
 	// header
 	packet[0] = DMX_PRO_START_MSG;
@@ -94,7 +94,7 @@ void ofxDmx::activateMk2(unsigned char key0, unsigned char key1, unsigned char k
 	// step 2, enable both ports
 	dataSize = 2;
 	packetSize = DMX_PRO_HEADER_SIZE + dataSize + DMX_PRO_END_SIZE;
-	vector<unsigned char> packet2(packetSize);
+	std::vector<unsigned char> packet2(packetSize);
 	
 	// header
 	packet2[0] = DMX_PRO_START_MSG;
@@ -126,7 +126,7 @@ void ofxDmx::update(bool force) {
 
 			unsigned int dataSize = levels.size() + DMX_START_CODE_SIZE;
 			unsigned int packetSize = DMX_PRO_HEADER_SIZE + dataSize + DMX_PRO_END_SIZE;
-			vector<unsigned char> packet(packetSize);
+			std::vector<unsigned char> packet(packetSize);
 			
 			// header
 			packet[0] = DMX_PRO_START_MSG;

--- a/src/ofxDmx.h
+++ b/src/ofxDmx.h
@@ -12,7 +12,7 @@ public:
 	// connect to the serial port. valid number of channels is 24-512. performance
 	// is directly related to the number of channels, so use the minimum required.
 	bool connect(int device = 0, unsigned int channels = 24);
-	bool connect(string device, unsigned int channels = 24);
+	bool connect(std::string device, unsigned int channels = 24);
 	void activateMk2(unsigned char key0 = 0xC8, unsigned char key1 = 0xD0, unsigned char key2 = 0x88, unsigned char key3 = 0xAD);
 	void disconnect();
 	
@@ -27,8 +27,8 @@ public:
 private:	
 	int connected;
 	int universes;
-	vector<unsigned char> levels;
-	vector<unsigned char> levels2;	// 2nd universe, only for MK2
+	std::vector<unsigned char> levels;
+	std::vector<unsigned char> levels2;	// 2nd universe, only for MK2
 	ofSerial serial;
 	bool needsUpdate;
 	


### PR DESCRIPTION
it just adds the std:: prefix to c++ vectors and strings to let ofxDmx compile on with the oF 0.10 releases and the master branch