### PR TITLE
Make ofSerial accessable

### DIFF
--- a/example/src/main.cpp
+++ b/example/src/main.cpp
@@ -1,8 +1,6 @@
 #include "ofApp.h"
-#include "ofAppGlutWindow.h"
 
-int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 512, 256, OF_WINDOW);
+int main(){
+	ofSetupOpenGL(512, 256, OF_WINDOW);
 	ofRunApp(new ofApp());
 }

--- a/readme.md
+++ b/readme.md
@@ -40,9 +40,4 @@ Development Notes for updating to include the Enttec OpenDMX module
 
 http://www.enttec.com/download/examples/OpenDMX.cs
 
-## Runig on Raspberry Pi
-
-    [notice ] ofSerial: [0] = ttyUSB0
-    [notice ] ofSerial: opening /dev/tty.usbserial-EN143965 @ 57600 bps
-    [ error ] ofSerial: unable to open /dev/tty.usbserial-EN143965
 

--- a/readme.md
+++ b/readme.md
@@ -39,3 +39,10 @@ If everything went Ok, you should now be able to open the generated project and 
 Development Notes for updating to include the Enttec OpenDMX module
 
 http://www.enttec.com/download/examples/OpenDMX.cs
+
+## Runig on Raspberry Pi
+
+    [notice ] ofSerial: [0] = ttyUSB0
+    [notice ] ofSerial: opening /dev/tty.usbserial-EN143965 @ 57600 bps
+    [ error ] ofSerial: unable to open /dev/tty.usbserial-EN143965
+

--- a/src/ofxDmx.cpp
+++ b/src/ofxDmx.cpp
@@ -88,9 +88,6 @@ void ofxDmx::activateMk2(unsigned char key0, unsigned char key1, unsigned char k
 	ofSleepMillis(200);
 	cout << "MK2: activated with API key" << endl;
 
-
-
-
 	// step 2, enable both ports
 	dataSize = 2;
 	packetSize = DMX_PRO_HEADER_SIZE + dataSize + DMX_PRO_END_SIZE;

--- a/src/ofxDmx.cpp
+++ b/src/ofxDmx.cpp
@@ -32,7 +32,7 @@ bool ofxDmx::connect(int device, unsigned int channels) {
 	return connected;
 }
 
-bool ofxDmx::connect(string device, unsigned int channels) {
+bool ofxDmx::connect(std::string device, unsigned int channels) {
 	serial.listDevices();
 	connected = serial.setup(device.c_str(), 57600);
 	setChannels(channels);

--- a/src/ofxDmx.h
+++ b/src/ofxDmx.h
@@ -12,7 +12,7 @@ public:
 	// connect to the serial port. valid number of channels is 24-512. performance
 	// is directly related to the number of channels, so use the minimum required.
 	bool connect(int device = 0, unsigned int channels = 24);
-	bool connect(string device, unsigned int channels = 24);
+	bool connect(std::string device, unsigned int channels = 24);
 	void activateMk2(unsigned char key0 = 0xC8, unsigned char key1 = 0xD0, unsigned char key2 = 0x88, unsigned char key3 = 0xAD);
 	void disconnect();
 	
@@ -27,8 +27,8 @@ public:
 private:	
 	int connected;
 	int universes;
-	vector<unsigned char> levels;
-	vector<unsigned char> levels2;	// 2nd universe, only for MK2
+	std::vector<unsigned char> levels;
+	std::vector<unsigned char> levels2;	// 2nd universe, only for MK2
 	ofSerial serial;
 	bool needsUpdate;
 	

--- a/src/ofxDmx.h
+++ b/src/ofxDmx.h
@@ -23,13 +23,14 @@ public:
 	
 	void setChannels(unsigned int channels = 24); // change the number of channels
 	bool isConnected();
-	
+
+	ofSerial serial;
+
 private:	
 	int connected;
 	int universes;
 	std::vector<unsigned char> levels;
 	std::vector<unsigned char> levels2;	// 2nd universe, only for MK2
-	ofSerial serial;
 	bool needsUpdate;
 	
 	bool badChannel(unsigned int channel);


### PR DESCRIPTION
So we can check the connected devices before connecting. Or check if the device has been disconnected.
At the moment connected will always respond `true` after first connection. 

    // Check for disconnection and reconnect when plugged in again
    if (deviceListLen != dmx.serial.getDeviceList().size()){
        dmx.disconnect();
    };
    if (!dmx.isConnected()) {
        dmx.connect(deviceID);
    }
